### PR TITLE
Register native themes location

### DIFF
--- a/content/mu-plugins/register-theme-directory.php
+++ b/content/mu-plugins/register-theme-directory.php
@@ -1,0 +1,3 @@
+<?php
+
+register_theme_directory( ABSPATH . 'wp-content/themes/' );


### PR DESCRIPTION
Skeleton has [empty] content directory decoupled from core, which means that out of the box native themes are not available and can't be used overall or as parent themes either.

Commit adds mu-plugin 1-liner that registers theme directory in WP subrepo as additional one and makes native themes functional out of the box.
