### PR TITLE
Use mod_rewrite to block access to .git files/directories

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -6,5 +6,7 @@ RewriteBase /
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule . /index.php [L]
+
+RewriteRule (.*/)?\.git(/.*)? / [R=301,L]
 </IfModule>
 # END WordPress


### PR DESCRIPTION
I'm not sure if this had been considered, but it seems that .git may have a lot of information in it, that many may not wish to be publicly accessible.

I did a quick addition of a RewriteRule to redirect any request to .git to the root, but I could see arguments for having such requests be outright Forbidden, Gone, or rewritten to /index.php...
