### PR TITLE
Improved WP_CONTENT_URL definition. Takes into consideration whether the...

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -17,7 +17,9 @@ if ( file_exists( dirname( __FILE__ ) . '/local-config.php' ) ) {
 // Custom Content Directory
 // ========================
 define( 'WP_CONTENT_DIR', dirname( __FILE__ ) . '/content' );
-define( 'WP_CONTENT_URL', 'http://' . $_SERVER['HTTP_HOST'] . '/content' );
+
+$domain = ( defined('WP_HOME') ) ? WP_HOME : 'http://' . $_SERVER['HTTP_HOST'];
+define( 'WP_CONTENT_URL', $domain . '/content' );
 
 // ================================================
 // You almost certainly do not want to change these


### PR DESCRIPTION
... site

has WP_HOME defined. If it does, it'll use that, otherwise, stick with the
default setting. This is handy in case your site is in a subdirectory and you
have manually defined WP_HOME.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/markjaquith/wordpress-skeleton/41)

<!-- Reviewable:end -->
