### PR TITLE
Fix an issue that assumes the project is installed in the root.

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -17,7 +17,7 @@ if ( file_exists( dirname( __FILE__ ) . '/local-config.php' ) ) {
 // Custom Content Directory
 // ========================
 define( 'WP_CONTENT_DIR', dirname( __FILE__ ) . '/content' );
-define( 'WP_CONTENT_URL', 'http://' . $_SERVER['HTTP_HOST'] . '/content' );
+define( 'WP_CONTENT_URL', 'http://' . $_SERVER['HTTP_HOST'] . dirname( $_SERVER['PHP_SELF'] ) . '/content' );
 
 // ================================================
 // You almost certainly do not want to change these


### PR DESCRIPTION
`$_SERVER['HTTP_HOST']` fails when the project is installed in subfolder, e.g. `http://rooturl.tld/project/dir/`. Changing this to `$_SERVER['HTTP_HOST'] . dirname( $_SERVER['PHP_SELF'] )` fixes the issue.
